### PR TITLE
remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,5 @@
   },
   "files": [
     "dist"
-  ],
-  "peerDependencies": {
-    "@dcl/sdk": "^7.1.6"
-  }
+  ]
 }


### PR DESCRIPTION
Remove peer dependencies since it conflicts with manual installs of `@dcl/sdk@next` and overrides the desired version with one specified by peer dependencies